### PR TITLE
sometimes the tile comes undefined that this crash the game, the play…

### DIFF
--- a/Grid.js
+++ b/Grid.js
@@ -95,7 +95,7 @@ class Cell {
     canAccept(tile){
         return (
          this.tile == null || 
-         (this.mergeTile == null && this.tile.value === tile.value)
+         (this.mergeTile == null && Boolean(tile?.value) && this.tile.value === tile.value)
         )
     }
 


### PR DESCRIPTION
Sometimes the tile comes undefined that this crash the game, the play…er cannot continue until refresh the page, now with this line is working properly

Steps to reproduce:

Play until find a direction that don't have possible options to merge, so the game will broke, no cell is moved even if have space.

In this video I show hitting multiple directional keys and there's no result after broke.

https://github.com/carinebatista/2048-game/assets/44711197/9957ef80-ba86-4c54-8739-9b1af54c512f


